### PR TITLE
Event teardown

### DIFF
--- a/jquery.dragbetter.js
+++ b/jquery.dragbetter.js
@@ -44,7 +44,7 @@
     },
 
     teardown: function() {
-      $(this).off('dragenter.dragbetterenter');
+      $(this).off('.dragbetterenter');
     }
 
   };
@@ -79,7 +79,7 @@
     },
 
     teardown: function() {
-      $(this).off('dragleave.dragbetterleave');
+      $(this).off('.dragbetterleave');
     }
 
   };

--- a/jquery.dragbetter.js
+++ b/jquery.dragbetter.js
@@ -37,7 +37,7 @@
         self.dragbetterCollection.push(event.target);
       });
 
-      $self.on('drop.dragbetterenter', function () {
+      $self.on('drop.dragbetterenter dragend.dragbetterenter', function () {
         self.dragbetterCollection = [];
         $self.triggerHandler('dragbetterleave');
       });


### PR DESCRIPTION
- Remove all event Listeners on teardown.
- Clean up after the `dragend` event as well.
