### PR TITLE
Add originalEvent 

### DIFF
--- a/jquery.dragbetter.js
+++ b/jquery.dragbetter.js
@@ -31,15 +31,15 @@
       $self.on('dragenter.dragbetterenter', function (event) {
 
         if (self.dragbetterCollection.length === 0) {
-          $self.triggerHandler('dragbetterenter');
+          $self.triggerHandler({type: 'dragbetterenter', originalEvent: event.originalEvent || event});
         }
 
         self.dragbetterCollection.push(event.target);
       });
 
-      $self.on('drop.dragbetterenter dragend.dragbetterenter', function () {
+      $self.on('drop.dragbetterenter dragend.dragbetterenter', function (event) {
         self.dragbetterCollection = [];
-        $self.triggerHandler('dragbetterleave');
+        $self.triggerHandler({type:'dragbetterleave', originalEvent: event.originalEvent || event});
       });
     },
 
@@ -72,7 +72,7 @@
             self.dragbetterCollection.splice(currentElementIndex, 1);
 
           if (self.dragbetterCollection.length === 0) {
-            $self.triggerHandler('dragbetterleave');
+            $self.triggerHandler({type:'dragbetterleave', originalEvent: event.originalEvent || event});
           }
         }, 1);
       });


### PR DESCRIPTION
I needed information of the original event so I added this to the triggered event.

The `event.originalEvent || event` is because the event seems to pass twice through the stack and this would result in `event.originalEvent.originalEvent` on the resulting event.